### PR TITLE
fix: Switch assertions validating numbers to using "is number"

### DIFF
--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -3,7 +3,7 @@
   assert:
     that:
       - openssh_port is defined
-      - openssh_port | int
+      - openssh_port is number
       - openssh_port | int > 0
       - openssh_port | int < 65536
     quiet: yes
@@ -80,7 +80,7 @@
   assert:
     that:
       - openssh_max_auth_tries is defined
-      - openssh_max_auth_tries | int
+      - openssh_max_auth_tries is number
       - openssh_max_auth_tries | int >= 0
     quiet: yes
 
@@ -88,7 +88,7 @@
   assert:
     that:
       - openssh_max_sessions is defined
-      - openssh_max_sessions | int
+      - openssh_max_sessions is number
       - openssh_max_sessions | int >= 0
     quiet: yes
 
@@ -260,7 +260,7 @@
   assert:
     that:
       - openssh_x11_display_offset is defined
-      - openssh_x11_display_offset | int
+      - openssh_x11_display_offset is number
       - openssh_x11_display_offset | int > 0
     quiet: yes
 
@@ -324,7 +324,7 @@
   assert:
     that:
       - openssh_client_alive_interval is defined
-      - openssh_client_alive_interval | int
+      - openssh_client_alive_interval is number
       - openssh_client_alive_interval | int >= 0
     quiet: yes
 
@@ -332,7 +332,7 @@
   assert:
     that:
       - openssh_client_alive_count_max is defined
-      - openssh_client_alive_count_max | int
+      - openssh_client_alive_count_max is number
       - openssh_client_alive_count_max | int >= 0
     quiet: yes
 


### PR DESCRIPTION
---
name: Pull request
about: Switch to verifying that variable is a number by using the "is number" function for Ansible/jinja2

---

re: https://github.com/robertdebock/ansible-role-openssh/issues/3


**Describe the change**
The current code tests whether an incoming variable is a number by attempting `<variable> | int`. This has the side effect that when the variable is 0, this parses as "false". Non-zero incoming numbers will parse as "true". What really should happen here, if I'm understanding the intent of these asserts, is to test whether the variable can be parsed as a number. This change performs that test and allows variables that are 0.

