### PR TITLE
fix: Login grace time should be a number, not a string

### DIFF
--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -57,7 +57,8 @@
   assert:
     that:
       - openssh_login_grace_time is defined
-      - openssh_login_grace_time | length > 0
+      - openssh_login_grace_time is number
+      - openssh_login_grace_time | int > 0
     quiet: yes
 
 - name: test if openssh_permit_root_login is set correctly


### PR DESCRIPTION
---
name: Pull request
about: Login Grace Time should be parsed as a numeric variable, not a string

---

**Describe the change**
Switch asserts to pull in `openssh_login_grace_time` as an assumed number/int, not a string

## BREAKING

This may cause breaking changes for projects that have configured `openssh_login_grace_time` as a string