### PR TITLE
assert: permit_root_login: also allow some special login values

### DIFF
--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -66,7 +66,7 @@
     that:
       - openssh_permit_root_login is defined
       - openssh_permit_root_login is string
-      - openssh_permit_root_login in [ "yes", "no" ]
+      - openssh_permit_root_login in [ "yes", "no", "without-password", "prohibit-password", "forced-commands-only" ]
     quiet: yes
 
 - name: test if openssh_strict_modes is set correctly


### PR DESCRIPTION
For more info, please see sshd_config(5).

---
name: Pull request

If think you should probably allow more PermitRootLogin values, at least add the `without-password` option.

---

**Describe the change**
Also allow some special login values:

```
 PermitRootLogin
             Specifies whether root can log in using ssh(1).  The argument must be yes, prohibit-password, forced-commands-only, or no.  The default is prohibit-password.

             If this option is set to prohibit-password (or its deprecated alias, without-password), password and keyboard-interactive authentication are disabled for root.

             If this option is set to forced-commands-only, root login with public key authentication will be allowed, but only if the command option has been specified (which may be
             useful for taking remote backups even if root login is normally not allowed).  All other authentication methods are disabled for root.

             If this option is set to no, root is not allowed to log in.
```
