### PR TITLE
Add config option "AllowGroups"

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,12 @@ openssh_accept_envs:
 
 openssh_subsystem: sftp {{ openssh_sftp_server }}
 
-# Restrict access to this (space separated list) of users.
+# Restrict access to this (space separated list) of users or groups.
 # For example: "openssh_allow_users: root my_user"
 # openssh_allow_users: root
+
+# For example: "openssh_allow_groups: wheel my_group"
+# openssh_allow_groups: wheel
 ```
 
 ## [Requirements](#requirements)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -98,6 +98,9 @@ openssh_accept_envs:
 
 openssh_subsystem: sftp {{ openssh_sftp_server }}
 
-# Restrict access to this (space separated list) of users.
+# Restrict access to this (space separated list) of users or groups.
 # For example: "openssh_allow_users: root my_user"
 # openssh_allow_users: root
+
+# For example: "openssh_allow_groups: wheel my_group"
+# openssh_allow_groups: wheel

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -7,3 +7,4 @@
   roles:
     - role: ansible-role-openssh
       openssh_allow_users: root
+      openssh_allow_groups: root

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -16,3 +16,12 @@
       register: openssh_check_if_allowusers_is_set
       failed_when:
         - openssh_check_if_allowusers_is_set is changed
+
+    - name: Check if AllowGroups is set
+      ansible.builtin.lineinfile:
+        path: /etc/ssh/sshd_config
+        line: AllowGroups root
+      check_mode: yes
+      register: openssh_check_if_allowgroups_is_set
+      failed_when:
+        - openssh_check_if_allowgroups_is_set is changed

--- a/templates/sshd_config_Alpine.j2
+++ b/templates/sshd_config_Alpine.j2
@@ -74,3 +74,7 @@ Subsystem {{ openssh_subsystem }}
 {% if openssh_allow_users is defined %}
 AllowUsers {{ openssh_allow_users }}
 {% endif %}
+
+{% if openssh_allow_groups is defined %}
+AllowGroups {{ openssh_allow_groups }}
+{% endif %}

--- a/templates/sshd_config_Archlinux.j2
+++ b/templates/sshd_config_Archlinux.j2
@@ -81,3 +81,7 @@ Subsystem {{ openssh_subsystem }}
 {% if openssh_allow_users is defined %}
 AllowUsers {{ openssh_allow_users }}
 {% endif %}
+
+{% if openssh_allow_groups is defined %}
+AllowGroups {{ openssh_allow_groups }}
+{% endif %}

--- a/templates/sshd_config_Debian.j2
+++ b/templates/sshd_config_Debian.j2
@@ -82,3 +82,8 @@ Subsystem {{ openssh_subsystem }}
 {% if openssh_allow_users is defined %}
 AllowUsers {{ openssh_allow_users }}
 {% endif %}
+
+{% if openssh_allow_groups is defined %}
+AllowGroups {{ openssh_allow_groups }}
+{% endif %}
+

--- a/templates/sshd_config_Fedora.j2
+++ b/templates/sshd_config_Fedora.j2
@@ -83,3 +83,7 @@ Subsystem {{ openssh_subsystem }}
 {% if openssh_allow_users is defined %}
 AllowUsers {{ openssh_allow_users }}
 {% endif %}
+
+{% if openssh_allow_groups is defined %}
+AllowGroups {{ openssh_allow_groups }}
+{% endif %}

--- a/templates/sshd_config_RedHat-7.j2
+++ b/templates/sshd_config_RedHat-7.j2
@@ -84,3 +84,7 @@ Subsystem {{ openssh_subsystem }}
 {% if openssh_allow_users is defined %}
 AllowUsers {{ openssh_allow_users }}
 {% endif %}
+
+{% if openssh_allow_groups is defined %}
+AllowGroups {{ openssh_allow_groups }}
+{% endif %}

--- a/templates/sshd_config_RedHat.j2
+++ b/templates/sshd_config_RedHat.j2
@@ -150,3 +150,7 @@ Subsystem {{ openssh_subsystem }}
 {% if openssh_allow_users is defined %}
 AllowUsers {{ openssh_allow_users }}
 {% endif %}
+
+{% if openssh_allow_groups is defined %}
+AllowGroups {{ openssh_allow_groups }}
+{% endif %}

--- a/templates/sshd_config_Suse.j2
+++ b/templates/sshd_config_Suse.j2
@@ -82,3 +82,7 @@ Subsystem {{ openssh_subsystem }}
 {% if openssh_allow_users is defined %}
 AllowUsers {{ openssh_allow_users }}
 {% endif %}
+
+{% if openssh_allow_groups is defined %}
+AllowGroups {{ openssh_allow_groups }}
+{% endif %}


### PR DESCRIPTION
Add config option "AllowGroups"
---

**Description**
Add ssh config option "AllowGroups". If specified, login is allowed only for users whose primary group or supplementary group list matches one of the patterns.

**Testing**
New testcase added.
