### PR TITLE
Add TrustedCAKeys option to sshd_config templates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -98,6 +98,8 @@ openssh_accept_envs:
 
 openssh_subsystem: sftp {{ openssh_sftp_server }}
 
+openssh_trusted_user_ca_keys: none
+
 # Restrict access to this (space separated list) of users or groups.
 # For example: "openssh_allow_users: root my_user"
 # openssh_allow_users: root

--- a/templates/sshd_config_Archlinux.j2
+++ b/templates/sshd_config_Archlinux.j2
@@ -85,3 +85,5 @@ AllowUsers {{ openssh_allow_users }}
 {% if openssh_allow_groups is defined %}
 AllowGroups {{ openssh_allow_groups }}
 {% endif %}
+
+TrustedUserCAKeys {{ openssh_trusted_user_ca_keys }}

--- a/templates/sshd_config_Debian.j2
+++ b/templates/sshd_config_Debian.j2
@@ -87,3 +87,4 @@ AllowUsers {{ openssh_allow_users }}
 AllowGroups {{ openssh_allow_groups }}
 {% endif %}
 
+TrustedUserCAKeys {{ openssh_trusted_user_ca_keys }}

--- a/templates/sshd_config_Fedora.j2
+++ b/templates/sshd_config_Fedora.j2
@@ -87,3 +87,5 @@ AllowUsers {{ openssh_allow_users }}
 {% if openssh_allow_groups is defined %}
 AllowGroups {{ openssh_allow_groups }}
 {% endif %}
+
+TrustedUserCAKeys {{ openssh_trusted_user_ca_keys }}

--- a/templates/sshd_config_RedHat-7.j2
+++ b/templates/sshd_config_RedHat-7.j2
@@ -88,3 +88,5 @@ AllowUsers {{ openssh_allow_users }}
 {% if openssh_allow_groups is defined %}
 AllowGroups {{ openssh_allow_groups }}
 {% endif %}
+
+TrustedUserCAKeys {{ openssh_trusted_user_ca_keys }}

--- a/templates/sshd_config_RedHat.j2
+++ b/templates/sshd_config_RedHat.j2
@@ -154,3 +154,5 @@ AllowUsers {{ openssh_allow_users }}
 {% if openssh_allow_groups is defined %}
 AllowGroups {{ openssh_allow_groups }}
 {% endif %}
+
+TrustedUserCAKeys {{ openssh_trusted_user_ca_keys }}

--- a/templates/sshd_config_Suse.j2
+++ b/templates/sshd_config_Suse.j2
@@ -86,3 +86,5 @@ AllowUsers {{ openssh_allow_users }}
 {% if openssh_allow_groups is defined %}
 AllowGroups {{ openssh_allow_groups }}
 {% endif %}
+
+TrustedUserCAKeys {{ openssh_trusted_user_ca_keys }}


### PR DESCRIPTION
---
name: Pull request
about: Add TrustedCAKeys option to sshd_config templates

---

**Describe the change**
Feature is required for signed SSH certificates feature in Vault: https://www.vaultproject.io/docs/secrets/ssh/signed-ssh-certificates

**Testing**
In case a feature was added, how were tests performed?
No tests, ben een luie collega
